### PR TITLE
Fix dependencies for test-in-server-and-promote job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ workflows:
           name: test-in-server-and-promote
           context: "org-global"
           requires:
+            - publish_rabbitmq
             - publish_postgresql
           promotion_component_list: "circleci/server-postgres circleci/server-rabbitmq"
           filters:


### PR DESCRIPTION
This should now be blocking on both image publishing jobs.