### PR TITLE
[SourceGraph] Update server promotion contexts with github-readonly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ workflows:
                 - /^server-\d\..+/
       - scotty-orb/test-in-server-and-promote:
           name: test-in-server-and-promote
-          context: "org-global"
+          context: ["org-global", github-readonly]
           requires:
             - publish_rabbitmq
             - publish_postgresql


### PR DESCRIPTION
Add the github-readonly context to test-in-server-and-promote jobs to start to remediate the context crime of using the snyk github readonly token from org-global instead of just using the github-readonly context for the job.
## Changes Made
- replace the scotty-orb/test-in-server-and-promote job context with [org-global, github-readonly] clobbering the existing context.


PR opend via sourcegraph

[_Created by Sourcegraph batch change `jrahme-cci/AddGHReadOnlyContextForScotty`._](https://circleci.sourcegraphcloud.com/users/jrahme-cci/batch-changes/AddGHReadOnlyContextForScotty)