### PR TITLE
fix: Upgrade to 12.22 for CVEs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           environment:
             NAME: server-postgres
             DOCKERFILE_PATH: Dockerfile
-            MAJOR_VERSION: 12.16
+            MAJOR_VERSION: 12.22
           pwd: postgresql/12
   scan_rabbitmq:
     executor: ccc
@@ -54,7 +54,7 @@ jobs:
             NAME: server-postgres
             DOCKERFILE_PATH: Dockerfile
             DOCKER_REGISTRY: dockerhub
-            MAJOR_VERSION: 12.16
+            MAJOR_VERSION: 12.22
           pwd: postgresql/12
   publish_rabbitmq:
     executor: ccc

--- a/postgresql/12/Dockerfile
+++ b/postgresql/12/Dockerfile
@@ -10,7 +10,7 @@ ENV POSTGRESQL_BASE_DIR "/opt/bitnami/postgresql"
 ENV PATH="${POSTGRESQL_BASE_DIR}/bin:${PATH}"
 
 # Install PostgreSQL
-ENV POSTGRESQL_VERSION 12.16
+ENV POSTGRESQL_VERSION 12.22
 RUN install_packages clang dirmngr gosu gnupg libclang-dev libicu-dev libipc-run-perl libkrb5-dev libldap2-dev liblz4-dev locales libpam-dev libperl-dev libpython3-dev libreadline-dev libssl-dev libxml2-dev libxslt1-dev llvm llvm-dev postgresql-server-dev-all python3-dev tcl-dev uuid-dev
 RUN curl -sSL "https://ftp.postgresql.org/pub/source/v${POSTGRESQL_VERSION}/postgresql-${POSTGRESQL_VERSION}.tar.gz" | tar -xz && \
 	cd "postgresql-${POSTGRESQL_VERSION}" && \
@@ -116,7 +116,7 @@ RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
 COPY rootfs /
 RUN /opt/bitnami/scripts/postgresql/postunpack.sh
 RUN /opt/bitnami/scripts/locales/add-extra-locales.sh
-ENV APP_VERSION="12.16.0" \
+ENV APP_VERSION="12.22.0" \
     BITNAMI_APP_NAME="postgresql" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \

--- a/postgresql/12/prebuildfs/opt/bitnami/.bitnami_components.json
+++ b/postgresql/12/prebuildfs/opt/bitnami/.bitnami_components.json
@@ -3,6 +3,6 @@
         "arch": "amd64",
         "distro": "debian-11",
         "type": "NAMI",
-        "version": "12.16.0-1"
+        "version": "12.22.0-1"
     }
 }


### PR DESCRIPTION
12.16 is failing to publish due to CVEs:

```
CPE vulnerabilities:
    Name: cpe:2.3:a:postgresql:postgresql, Version: 12.16, Path: /opt/bitnami/postgresql/bin/postgres
        Failed policy: ccc-image-scan
        CVE-2023-5869, Severity: HIGH, Source: https://nvd.nist.gov/vuln/detail/CVE-2023-5869
            CVSS score: 8.8, CVSS exploitability score: 2.8
            Fixed version: 12.17
        CVE-2024-0985, Severity: HIGH, Source: https://nvd.nist.gov/vuln/detail/CVE-2024-0985
            CVSS score: 8, CVSS exploitability score: 2.1
            Fixed version: 12.18
        CVE-2024-10979, Severity: HIGH, Source: https://nvd.nist.gov/vuln/detail/CVE-2024-10979
            CVSS score: 8.8, CVSS exploitability score: 2.8
            Fixed version: 12.21
            Has public exploit
        CVE-2024-7348, Severity: HIGH, Source: https://nvd.nist.gov/vuln/detail/CVE-2024-7348
            CVSS score: 7.5, CVSS exploitability score: 1.6
            Fixed version: 12.20
        CVE-2023-5868, Severity: MEDIUM, Source: https://nvd.nist.gov/vuln/detail/CVE-2023-5868
            CVSS score: 4.3, CVSS exploitability score: 2.8
            Fixed version: 12.17
        CVE-2023-5870, Severity: MEDIUM, Source: https://nvd.nist.gov/vuln/detail/CVE-2023-5870
            CVSS score: 4.4, CVSS exploitability score: 0.7
            Fixed version: 12.17
        CVE-2024-10976, Severity: MEDIUM, Source: https://nvd.nist.gov/vuln/detail/CVE-2024-10976
            CVSS score: 5.4, CVSS exploitability score: 2.8
            Fixed version: 12.21
        CVE-2024-10978, Severity: MEDIUM, Source: https://nvd.nist.gov/vuln/detail/CVE-2024-10978
            CVSS score: 4.2, CVSS exploitability score: 1.6
            Fixed version: 12.21
        CVE-2024-10977, Severity: LOW, Source: https://nvd.nist.gov/vuln/detail/CVE-2024-10977
            CVSS score: 3.7, CVSS exploitability score: 2.2
            Fixed version: 12.21
```