### PR TITLE
Fix healthchecks to not require auth

### DIFF
--- a/helm/redis/templates/health-configmap.yaml
+++ b/helm/redis/templates/health-configmap.yaml
@@ -15,7 +15,7 @@ data:
     password_aux=`cat ${REDIS_PASSWORD_FILE}`
     export REDIS_PASSWORD=$password_aux
 {{- end }}
-    export REDISCLI_AUTH="$REDIS_PASSWORD"
+    [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
     response=$(
       timeout -s 3 $1 \
       redis-cli \
@@ -43,7 +43,7 @@ data:
     password_aux=`cat ${REDIS_PASSWORD_FILE}`
     export REDIS_PASSWORD=$password_aux
 {{- end }}
-    export REDISCLI_AUTH="$REDIS_PASSWORD"
+    [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
     response=$(
       timeout -s 3 $1 \
       redis-cli \
@@ -72,7 +72,7 @@ data:
     password_aux=`cat ${REDIS_PASSWORD_FILE}`
     export REDIS_PASSWORD=$password_aux
 {{- end }}
-    export REDISCLI_AUTH="$REDIS_PASSWORD"
+    [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
     response=$(
       timeout -s 3 $1 \
       redis-cli \
@@ -116,7 +116,7 @@ data:
     password_aux=`cat ${REDIS_MASTER_PASSWORD_FILE}`
     export REDIS_MASTER_PASSWORD=$password_aux
 {{- end }}
-    export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
+    [[ -n "$REDIS_MASTER_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
     response=$(
       timeout -s 3 $1 \
       redis-cli \
@@ -142,7 +142,7 @@ data:
     password_aux=`cat ${REDIS_MASTER_PASSWORD_FILE}`
     export REDIS_MASTER_PASSWORD=$password_aux
 {{- end }}
-    export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
+    [[ -n "$REDIS_MASTER_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
     response=$(
       timeout -s 3 $1 \
       redis-cli \


### PR DESCRIPTION
There's a good bit of information here: https://circleci.atlassian.net/browse/ONPREM-2493

But the tl;dr is that if Redis sees `REDISCLI_AUTH` set to even `""` it expects a password to be set, which makes the healthchecks fail. 
Since we don't set this by default, we can ignore it if it's not set.