### PR TITLE
Don't use image globals for RabbitMQ Helm chart

### DIFF
--- a/helm/rabbitmq/Chart.yaml
+++ b/helm/rabbitmq/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: rabbitmq
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
-version: 13.0.5
+version: 13.0.6

--- a/helm/rabbitmq/values.yaml
+++ b/helm/rabbitmq/values.yaml
@@ -13,12 +13,12 @@
 ## @param global.storageClass Global StorageClass for Persistent Volume(s)
 ##
 global:
-  imageRegistry: "cciserver.azurecr.io"
+  imageRegistry: ""
   ## E.g.
   ## imagePullSecrets:
   ##   - myRegistryKeySecretName
   ##
-  imagePullSecrets: [regcred]
+  imagePullSecrets: []
   storageClass: ""
   ## Compatibility adaptations for Kubernetes platforms
   ##
@@ -41,6 +41,7 @@ global:
 ## @param image.debug Set to true if you would like to see extra information on logs
 ##
 image:
+  registry: "cciserver.azurecr.io"
   repository: server-rabbitmq
   tag: 3.12.423-3363c50
   digest: ""
@@ -60,7 +61,7 @@ image:
   ## pullSecrets:
   ##   - myRegistryKeySecretName
   ##
-  pullSecrets: []
+  pullSecrets: [regcred]
 ## @section Common parameters
 ##
 


### PR DESCRIPTION
This made overriding the image registry under the rabbitmq.image stanza not work