### PR TITLE
Add version check for charts when there are changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,11 @@ executors:
           password: $DOCKER_HUB_PASSWORD
 
 commands:
-  notify_failing_main:
+  notify_failing_branch:
     steps:
       - slack/notify:
           channel: server-alerts
-          branch_pattern: main
+          branch_pattern: main, server-[0-9]\.[0-9]+
           event: fail
           template: basic_fail_1
   set_up_container:
@@ -29,6 +29,13 @@ commands:
     steps:
       - setup_remote_docker
       - checkout
+  install_packagecloud_cli:
+    steps:
+      - run:
+          name: Install package_cloud
+          command: |
+            sudo apt-get update && sudo apt-get install ruby-rubygems -y
+            sudo gem install --no-document package_cloud
 
 jobs:
   # Images
@@ -116,7 +123,7 @@ jobs:
       - run:
           command: ./do kubeconform
           when: always
-      - notify_failing_main
+      - notify_failing_branch
   package-charts:
     executor: deploy
     steps:
@@ -144,7 +151,14 @@ jobs:
       - persist_to_workspace:
           root: .
           paths: [./target]
-      - notify_failing_main
+      - notify_failing_branch
+  check-version-bump:
+    executor: deploy
+    steps:
+      - checkout
+      - run:
+          name: Check if charts changed and version is bumped accordingly
+          command: ./do check-version-bump
   publish-chart:
     executor: deploy
     parameters:
@@ -156,17 +170,14 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run:
-          name: Install package_cloud
-          command: |
-            sudo apt-get update && sudo apt-get install ruby-rubygems -y
-            sudo gem install --no-document package_cloud
+      - install_packagecloud_cli
       - run:
           name: Publish Helm chart
           command: |
             package_cloud push circleci/<< parameters.repo >>/helm/v1 \
               ./target/<< parameters.chart_name >>*.tgz
-      - notify_failing_main
+      - notify_failing_branch
+
 
 workflows:
   my-workflow:
@@ -231,9 +242,10 @@ workflows:
 
       # Chart jobs
       - validate-charts
+      - check-version-bump
       - package-charts:
           context: releng-signing
-          requires: [validate-charts]
+          requires: [validate-charts, check-version-bump]
       # Mongo chart
       - approve-publish-mongo-chart:
           type: approval

--- a/do
+++ b/do
@@ -11,9 +11,7 @@ kubeconform() {
 
     for chart_dir in ./helm/*/; do
         if [[ -f "$chart_dir/Chart.yaml" ]]; then
-            # TODO: Skip postgresql chart - failing validation
-            if [[ "$chart_dir" == *"postgresql"* ||  "$chart_dir" == *"common"* ]]; then
-                echo "Skipping chart: $chart_dir (TODO: fix validation issues)"
+            if [[ "$chart_dir" == *"common"* ]]; then
                 continue
             fi
 


### PR DESCRIPTION
Testing after committing a change to the Mongo chart:
```bash
 $ ./do check-version-bump                                                                                                                                                                   
Chart mongodb changed, checking version 10.4.4 in Packagecloud
Error: mongodb-10.4.4 already exists. Please bump version in ./helm/mongodb/Chart.yaml
```

Testing after setting `CIRLCE_BRANCH=server-4.9` and incrementing the version:
```bash
./do check-version-bump                                                                                                                                                                   
Chart mongodb changed, checking version 10.4.5 in Packagecloud
Error: Version 10.4.5 should be suffixed with -server-4.9 for branch server-4.9
```