### PR TITLE
[ONPREM-2478] Fix Dockerfile path for publish_postgresql job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,8 +98,8 @@ jobs:
             NAME: server-postgres
             DOCKERFILE_PATH: Dockerfile
             DOCKER_REGISTRY: dockerhub
-            MAJOR_VERSION: 12.22
-          pwd: postgresql/12
+            MAJOR_VERSION: 13.21
+          pwd: postgresql/13
   publish_rabbitmq:
     executor: ccc
     steps:


### PR DESCRIPTION
Forgot to update this for Postgres 13