### PR TITLE
update pg version to 13.22

### DIFF
--- a/postgresql/13/Dockerfile
+++ b/postgresql/13/Dockerfile
@@ -10,7 +10,7 @@ ENV POSTGRESQL_BASE_DIR "/opt/bitnami/postgresql"
 ENV PATH="${POSTGRESQL_BASE_DIR}/bin:${PATH}"
 
 # Install PostgreSQL
-ENV POSTGRESQL_VERSION 13.21
+ENV POSTGRESQL_VERSION 13.22
 RUN install_packages clang dirmngr gosu gnupg libclang-dev libicu-dev libipc-run-perl libkrb5-dev libldap2-dev liblz4-dev locales libpam-dev libperl-dev libpython3-dev libreadline-dev libssl-dev libxml2-dev libxslt1-dev llvm llvm-dev postgresql-server-dev-all python3-dev tcl-dev uuid-dev
 RUN curl -sSL "https://ftp.postgresql.org/pub/source/v${POSTGRESQL_VERSION}/postgresql-${POSTGRESQL_VERSION}.tar.gz" | tar -xz && \
 	cd "postgresql-${POSTGRESQL_VERSION}" && \


### PR DESCRIPTION
this version bump patches the following CVEs
- https://www.postgresql.org/support/security/CVE-2025-8714/
- https://www.postgresql.org/support/security/CVE-2025-8715/