### PR TITLE
[ONPREM-2899] Fix version tagging to use x.y form instead of x-only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,8 +69,11 @@ jobs:
             DOCKERFILE_PATH: Dockerfile
             DOCKER_REGISTRY: dockerhub
           command: |
-            NAME="server-$(dirname << parameters.service_path >>)" \
-            MAJOR_VERSION="$(basename << parameters.service_path >>)" \
+            service="$(dirname << parameters.service_path >>)"
+            version="$(grep -m1 "^ARG ${service^^}_VERSION=" Dockerfile | cut -d= -f2)"
+
+            NAME="server-${service}" \
+            MAJOR_VERSION="$(echo "${version}" | cut -d. -f1,2)" \
             << parameters.command >>
       - slack/notify:
           channel: server-alerts

--- a/mongodb/7/Dockerfile
+++ b/mongodb/7/Dockerfile
@@ -4,6 +4,8 @@
 
 FROM docker.io/bitnami/minideb:bookworm
 
+ARG MONGODB_VERSION=7.0.15
+
 ENV HOME="/" \
     OS_ARCH="amd64" \
     OS_FLAVOUR="debian-12" \
@@ -31,7 +33,7 @@ RUN mkdir -p /opt/bitnami/common/bin /tmp/downloads && cd /tmp/downloads && \
     tar -xzf mongosh.tgz && \
     cp mongosh-*/bin/* /opt/bitnami/common/bin/ && \
     \
-    curl -L -o mongodb.tgz https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian12-7.0.15.tgz && \
+    curl -L -o mongodb.tgz https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-debian12-${MONGODB_VERSION}.tgz && \
     tar -xzf mongodb.tgz && \
     cp mongodb-linux-*/bin/* /opt/bitnami/common/bin/ && \
     \
@@ -45,7 +47,7 @@ RUN find / -perm /6000 -type f -exec chmod a-s {} \; || true
 
 COPY rootfs /
 RUN /opt/bitnami/scripts/mongodb/postunpack.sh
-ENV APP_VERSION="7.0.15" \
+ENV APP_VERSION="${MONGODB_VERSION}" \
     BITNAMI_APP_NAME="mongodb" \
     PATH="/opt/bitnami/common/bin:/opt/bitnami/mongodb/bin:$PATH"
 

--- a/postgres/13/Dockerfile
+++ b/postgres/13/Dockerfile
@@ -10,7 +10,8 @@ ENV POSTGRESQL_BASE_DIR "/opt/bitnami/postgresql"
 ENV PATH="${POSTGRESQL_BASE_DIR}/bin:${PATH}"
 
 # Install PostgreSQL
-ENV POSTGRESQL_VERSION 13.23
+ARG POSTGRES_VERSION=13.23
+ENV POSTGRESQL_VERSION ${POSTGRES_VERSION}
 RUN install_packages clang dirmngr gosu gnupg libclang-dev libicu-dev libipc-run-perl libkrb5-dev libldap2-dev liblz4-dev locales libpam-dev libperl-dev libpython3-dev libreadline-dev libssl-dev libxml2-dev libxslt1-dev llvm llvm-dev postgresql-server-dev-all python3-dev tcl-dev uuid-dev
 RUN curl -sSL "https://ftp.postgresql.org/pub/source/v${POSTGRESQL_VERSION}/postgresql-${POSTGRESQL_VERSION}.tar.gz" | tar -xz && \
 	cd "postgresql-${POSTGRESQL_VERSION}" && \

--- a/postgres/18/Dockerfile
+++ b/postgres/18/Dockerfile
@@ -10,7 +10,8 @@ ENV POSTGRESQL_BASE_DIR "/opt/bitnami/postgresql"
 ENV PATH="${POSTGRESQL_BASE_DIR}/bin:${PATH}"
 
 # Install PostgreSQL
-ENV POSTGRESQL_VERSION 18.2
+ARG POSTGRES_VERSION=18.2
+ENV POSTGRESQL_VERSION ${POSTGRES_VERSION}
 RUN install_packages bison clang dirmngr flex gosu gnupg libclang-dev libicu-dev libipc-run-perl libkrb5-dev libldap2-dev liblz4-dev locales libpam-dev libperl-dev libpython3-dev libreadline-dev libssl-dev libxml2-dev libxslt1-dev llvm llvm-dev meson ninja-build postgresql-server-dev-all python3-dev tcl-dev uuid-dev
 RUN curl -sSL "https://ftp.postgresql.org/pub/source/v${POSTGRESQL_VERSION}/postgresql-${POSTGRESQL_VERSION}.tar.gz" | tar -xz && \
 	cd "postgresql-${POSTGRESQL_VERSION}" && \

--- a/redis/6/Dockerfile
+++ b/redis/6/Dockerfile
@@ -4,20 +4,23 @@
 
 # Build stage for Redis
 FROM docker.io/bitnami/minideb:buster as redis-builder
+
+ARG REDIS_VERSION=6.2.20
+
 RUN sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list && \
     sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list && \
     sed -i '/stretch-updates/d' /etc/apt/sources.list
 RUN install_packages build-essential wget make gcc ca-certificates
-RUN wget -O redis.tar.gz https://github.com/redis/redis/archive/refs/tags/6.2.20.tar.gz \
+RUN wget -O redis.tar.gz https://github.com/redis/redis/archive/refs/tags/${REDIS_VERSION}.tar.gz \
     && tar -xzf redis.tar.gz \
-    && cd redis-6.2.20 \
+    && cd redis-${REDIS_VERSION} \
     && make \
     && make install PREFIX=/opt/bitnami/redis \
     && mkdir -p /opt/bitnami/redis/etc \
     && cp redis.conf /opt/bitnami/redis/etc/redis-default.conf \
     && strip /opt/bitnami/redis/bin/* \
     && cd .. \
-    && rm -rf redis-6.2.20 redis.tar.gz
+    && rm -rf redis-${REDIS_VERSION} redis.tar.gz
 
 # Build stage for wait-for-port
 FROM docker.io/bitnami/minideb:buster as wait-for-port-builder


### PR DESCRIPTION
My refactor in #138 inadvertently made only the major version to be used in tagging, causing [promotion job failures](https://app.circleci.com/pipelines/github/circleci/server-docker-images/766/workflows/5ca2a4a4-b85c-4757-b06e-526597c3ad13/jobs/3637?invite=true#step-103-593_54) where tags must be of the form x.y. Each Dockerfile now defines a standardized ARG <SERVICE>_VERSION for the CI to derive the MAJOR_VERSION.