### PR TITLE
[backplane/repo-fixer] upgrade docker resource classes to gen2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ executors:
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASSWORD
+    resource_class: medium.gen2
 
 workflows:
   my-workflow:


### PR DESCRIPTION
> [!IMPORTANT]
> <sub>This PR was AI-generated by the [backplane-cicd repo-fixer pipeline](https://github.com/circleci/backplane-cicd/blob/main/pipelines/repo-fixer.yml). Give feedback in [#backplane-ecosystem](https://circleci.slack.com/archives/C06BR4CLXAT).</sub>

upgrade docker resource classes to gen2

Append .gen2 to docker executor resource_class values.

Jobs with circleci_ip_ranges are left unchanged (incompatible).

Jobs without an explicit resource_class get medium.gen2 (the default was medium).

See: https://circleci.slack.com/archives/C07M73TT8/p1776957768572589