### PR TITLE
Update ERLANG to 27.3.4.10

### DIFF
--- a/rabbitmq/3/Dockerfile
+++ b/rabbitmq/3/Dockerfile
@@ -4,7 +4,8 @@
 
 FROM debian:bookworm-slim AS builder
 
-ARG ERLANG_VERSION=27.3.4.2
+# renovate: datasource=github-releases depName=erlang/otp extractVersion=^OTP-(?<version>.+)$
+ARG ERLANG_VERSION=27.3.4.10
 ARG RABBITMQ_VERSION=3.12.14
 
 # Install build dependencies

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["local>circleci/renovate-config", "github>circleci/renovate-config:default"]
 }


### PR DESCRIPTION
Updates ERLANG to 27.3.4.10

Also updates the renovate config to use the default one for CircleCI. This gets us server branches. 

We'll need to go through each Dockerfile and manually add the `# renovate` source above each environment variable we want to be watched.