### PR TITLE
[ONPREM-3384] Add Postgres 12-to-14 pg_upgrade helper image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
           matrix:
             alias: scan
             parameters:
-              service_path: [postgres/13, postgres/14, postgres/18, rabbitmq/3, redis/6, mongodb/7]
+              service_path: [postgres/13, postgres/14, postgres/18, postgres/upgrade_helpers/12-14, rabbitmq/3, redis/6, mongodb/7]
           context: "org-global"
           filters:
             branches:
@@ -36,7 +36,7 @@ workflows:
             alias: publish
             parameters:
               # TODO: Publish and promote postgres/18 after ONPREM-2563
-              service_path: [postgres/13, postgres/14, rabbitmq/3, redis/6, mongodb/7]
+              service_path: [postgres/13, postgres/14, postgres/upgrade_helpers/12-14, rabbitmq/3, redis/6, mongodb/7]
           context: "org-global"
           filters: &publish_filters
             branches:
@@ -70,11 +70,21 @@ jobs:
             DOCKERFILE_PATH: Dockerfile
             DOCKER_REGISTRY: dockerhub
           command: |
-            service="$(dirname << parameters.service_path >>)"
-            version="$(grep -m1 "^ARG ${service^^}_VERSION=" Dockerfile | cut -d= -f2)"
+            case "<< parameters.service_path >>" in
+              postgres/upgrade_helpers/*)
+                NAME="server-postgres-upgrade"
+                MAJOR_VERSION="$(basename << parameters.service_path >>)"
+                ;;
+              *)
+                service="$(dirname << parameters.service_path >>)"
+                version="$(grep -m1 "^ARG ${service^^}_VERSION=" Dockerfile | cut -d= -f2)"
+                NAME="server-${service}"
+                MAJOR_VERSION="$(echo "${version}" | cut -d. -f1,2)"
+                ;;
+            esac
 
-            NAME="server-${service}" \
-            MAJOR_VERSION="$(echo "${version}" | cut -d. -f1,2)" \
+            NAME="$NAME" \
+            MAJOR_VERSION="$MAJOR_VERSION" \
             << parameters.command >>
       - slack/notify:
           channel: server-alerts

--- a/postgres/upgrade_helpers/12-14/Dockerfile
+++ b/postgres/upgrade_helpers/12-14/Dockerfile
@@ -1,0 +1,29 @@
+FROM postgres:14-bookworm
+
+RUN sed -i 's/$/ 12/' /etc/apt/sources.list.d/pgdg.list
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		postgresql-12='12.22-3.pgdg12+1' \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV PGBINOLD /usr/lib/postgresql/12/bin
+ENV PGBINNEW /usr/lib/postgresql/14/bin
+
+ENV PGDATAOLD /var/lib/postgresql/12/data
+ENV PGDATANEW /var/lib/postgresql/14/data
+
+RUN set -eux; \
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+WORKDIR /var/lib/postgresql
+
+COPY docker-upgrade /usr/local/bin/
+
+ENTRYPOINT ["docker-upgrade"]
+
+# recommended: --link
+CMD ["pg_upgrade"]

--- a/postgres/upgrade_helpers/12-14/LICENSE
+++ b/postgres/upgrade_helpers/12-14/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2014-2015, Docker PostgreSQL Authors (See AUTHORS)
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/postgres/upgrade_helpers/12-14/README.md
+++ b/postgres/upgrade_helpers/12-14/README.md
@@ -1,0 +1,5 @@
+# postgres-upgrade 12 → 14
+
+A `pg_upgrade` helper image that bundles PostgreSQL 12 and 14 binaries in a single container so `pg_upgrade` can perform an in-place major-version upgrade of a PostgreSQL 12 data directory to PostgreSQL 14. The image is built on `postgres:14-bookworm` with `postgresql-12` installed alongside it, exposing both binary trees via `PGBINOLD` (`/usr/lib/postgresql/12/bin`) and `PGBINNEW` (`/usr/lib/postgresql/14/bin`). The `docker-upgrade` entrypoint wraps `pg_upgrade` with the `initdb` and permission setup needed for the upgrade to run unattended.
+
+The `Dockerfile` and `docker-upgrade` script were copied from [tianon/docker-postgres-upgrade](https://github.com/tianon/docker-postgres-upgrade) and are used under the terms of its MIT license; a verbatim copy of that license is included in this directory as [`LICENSE`](./LICENSE). The only local change is pinning the `postgresql-12` `.deb` to a specific pgdg version for reproducible builds.

--- a/postgres/upgrade_helpers/12-14/docker-upgrade
+++ b/postgres/upgrade_helpers/12-14/docker-upgrade
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+if [ "$#" -eq 0 -o "${1:0:1}" = '-' ]; then
+	set -- pg_upgrade "$@"
+fi
+
+if [ "$1" = 'pg_upgrade' -a "$(id -u)" = '0' ]; then
+	mkdir -p "$PGDATAOLD" "$PGDATANEW"
+	chmod 700 "$PGDATAOLD" "$PGDATANEW"
+	chown postgres .
+	chown -R postgres "$PGDATAOLD" "$PGDATANEW"
+	exec gosu postgres "$BASH_SOURCE" "$@"
+fi
+
+if [ "$1" = 'pg_upgrade' ]; then
+	if [ ! -s "$PGDATANEW/PG_VERSION" ]; then
+		PGDATA="$PGDATANEW" eval "initdb $POSTGRES_INITDB_ARGS"
+	fi
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary

- Adds a new `pg_upgrade` helper image at `postgres/upgrade_helpers/12-14/` that bundles PostgreSQL 12 and 14 binaries in one container, enabling an in-place major-version upgrade of a pg12 data directory to pg14.
- Built on `postgres:14-bookworm` with `postgresql-12` installed alongside; exposes both binary trees via `PGBINOLD` / `PGBINNEW`. The `docker-upgrade` entrypoint wraps `pg_upgrade` with the `initdb` and permission setup needed for an unattended run.
- `Dockerfile` and `docker-upgrade` were copied from [tianon/docker-postgres-upgrade](https://github.com/tianon/docker-postgres-upgrade) and are used under its MIT license. A verbatim copy of the upstream `LICENSE` is vendored in this directory alongside a short `README.md` that attributes the source.

## Local changes from upstream

- Pinned `postgresql-12` to `12.22-3.pgdg12+1` for reproducible builds (upstream's pinned version is no longer published in the pgdg repo).

## Notes

- The image is **amd64-only**: pgdg does not publish `postgresql-12` server packages for arm64, so a multi-arch build is not possible without finding pg12 server binaries elsewhere.

## Test plan

- [ ] `docker buildx build --platform linux/amd64 -t postgres-upgrade:12-to-14 postgres/upgrade_helpers/12-14/` completes successfully
- [ ] Resulting image contains both `/usr/lib/postgresql/12/bin/postgres` and `/usr/lib/postgresql/14/bin/postgres`
- [ ] `docker run --rm postgres-upgrade:12-to-14 pg_upgrade --help` prints help text via the `docker-upgrade` entrypoint
- [ ] End-to-end smoke test: run against a real pg12 data directory and verify the upgraded cluster starts under pg14