### PR TITLE
Update ERLANG to 27.3.4.15

### DIFF
--- a/postgres/14/Dockerfile
+++ b/postgres/14/Dockerfile
@@ -10,7 +10,7 @@ ENV POSTGRESQL_BASE_DIR "/opt/bitnami/postgresql"
 ENV PATH="${POSTGRESQL_BASE_DIR}/bin:${PATH}"
 
 # Install PostgreSQL
-ARG POSTGRES_VERSION=14.22
+ARG POSTGRES_VERSION=14.23
 ENV POSTGRESQL_VERSION ${POSTGRES_VERSION}
 RUN install_packages clang dirmngr gosu gnupg libclang-dev libicu-dev libipc-run-perl libkrb5-dev libldap2-dev liblz4-dev locales libpam-dev libperl-dev libpython3-dev libreadline-dev libssl-dev libxml2-dev libxslt1-dev llvm llvm-dev postgresql-server-dev-all python3-dev tcl-dev uuid-dev
 RUN curl -sSL "https://ftp.postgresql.org/pub/source/v${POSTGRESQL_VERSION}/postgresql-${POSTGRESQL_VERSION}.tar.gz" | tar -xz && \
@@ -117,7 +117,7 @@ RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
 COPY rootfs /
 RUN /opt/bitnami/scripts/postgresql/postunpack.sh
 RUN /opt/bitnami/scripts/locales/add-extra-locales.sh
-ENV APP_VERSION="14.22.0" \
+ENV APP_VERSION="14.23.0" \
     BITNAMI_APP_NAME="postgresql" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \

--- a/postgres/18/Dockerfile
+++ b/postgres/18/Dockerfile
@@ -10,7 +10,7 @@ ENV POSTGRESQL_BASE_DIR "/opt/bitnami/postgresql"
 ENV PATH="${POSTGRESQL_BASE_DIR}/bin:${PATH}"
 
 # Install PostgreSQL
-ARG POSTGRES_VERSION=18.2
+ARG POSTGRES_VERSION=18.4
 ENV POSTGRESQL_VERSION ${POSTGRES_VERSION}
 RUN install_packages bison clang dirmngr flex gosu gnupg libclang-dev libicu-dev libipc-run-perl libkrb5-dev libldap2-dev liblz4-dev locales libpam-dev libperl-dev libpython3-dev libreadline-dev libssl-dev libxml2-dev libxslt1-dev llvm llvm-dev meson ninja-build postgresql-server-dev-all python3-dev tcl-dev uuid-dev
 RUN curl -sSL "https://ftp.postgresql.org/pub/source/v${POSTGRESQL_VERSION}/postgresql-${POSTGRESQL_VERSION}.tar.gz" | tar -xz && \
@@ -114,7 +114,7 @@ RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
 COPY rootfs /
 RUN /opt/bitnami/scripts/postgresql/postunpack.sh
 RUN /opt/bitnami/scripts/locales/add-extra-locales.sh
-ENV APP_VERSION="18.2.0" \
+ENV APP_VERSION="18.4.0" \
     BITNAMI_APP_NAME="postgresql" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \

--- a/rabbitmq/3/Dockerfile
+++ b/rabbitmq/3/Dockerfile
@@ -5,7 +5,7 @@
 FROM debian:bookworm-slim AS builder
 
 # renovate: datasource=github-releases depName=erlang/otp extractVersion=^OTP-(?<version>.+)$
-ARG ERLANG_VERSION=27.3.4.10
+ARG ERLANG_VERSION=27.3.4.15
 ARG RABBITMQ_VERSION=3.12.14
 
 # Install build dependencies


### PR DESCRIPTION
## What
Bump Erlang/OTP in `rabbitmq/3/Dockerfile` from `27.3.4.10` → `27.3.4.15`.

## Why
The `publish_rabbitmq` job fails the Wiz `ccc-image-scan` policy gate (`wizcli: exit status 4`, verdict `FAILED_BY_POLICY`). The blocking findings are two HIGH Erlang/OTP CVEs present in 27.3.4.10:

| CVE | Severity | Fixed in |
|-----|----------|----------|
| CVE-2026-49759 | HIGH | 27.3.4.13 |
| CVE-2026-42790 | HIGH | 27.3.4.12 |

`27.3.4.15` is the latest 27.3.4.x patch and clears every Erlang/OTP CVE the scan flagged. The `OTP-27.3.4.15` source tarball (built from source in this Dockerfile) is confirmed available on the erlang/otp releases.

Failing build: `server-docker-images` pipeline 987 / build 4789.

## Follow-ups (separate PRs)
- Backport to `server-4.9` (where 4789 failed), `server-4.8`, `server-4.10`.
- The `# renovate:` annotation on this ARG is inert — the shared renovate-config preset has no customManager to parse it, so these bumps stay manual until that's addressed.
