### PR TITLE
Backport to server-4.10: Erlang 27.3.4.15 + Postgres 18.4 (CVE fix)

### DIFF
--- a/postgres/18/Dockerfile
+++ b/postgres/18/Dockerfile
@@ -10,7 +10,7 @@ ENV POSTGRESQL_BASE_DIR "/opt/bitnami/postgresql"
 ENV PATH="${POSTGRESQL_BASE_DIR}/bin:${PATH}"
 
 # Install PostgreSQL
-ARG POSTGRES_VERSION=18.2
+ARG POSTGRES_VERSION=18.4
 ENV POSTGRESQL_VERSION ${POSTGRES_VERSION}
 RUN install_packages bison clang dirmngr flex gosu gnupg libclang-dev libicu-dev libipc-run-perl libkrb5-dev libldap2-dev liblz4-dev locales libpam-dev libperl-dev libpython3-dev libreadline-dev libssl-dev libxml2-dev libxslt1-dev llvm llvm-dev meson ninja-build postgresql-server-dev-all python3-dev tcl-dev uuid-dev
 RUN curl -sSL "https://ftp.postgresql.org/pub/source/v${POSTGRESQL_VERSION}/postgresql-${POSTGRESQL_VERSION}.tar.gz" | tar -xz && \
@@ -114,7 +114,7 @@ RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen
 COPY rootfs /
 RUN /opt/bitnami/scripts/postgresql/postunpack.sh
 RUN /opt/bitnami/scripts/locales/add-extra-locales.sh
-ENV APP_VERSION="18.2.0" \
+ENV APP_VERSION="18.4.0" \
     BITNAMI_APP_NAME="postgresql" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \

--- a/rabbitmq/3/Dockerfile
+++ b/rabbitmq/3/Dockerfile
@@ -5,7 +5,7 @@
 FROM debian:bookworm-slim AS builder
 
 # renovate: datasource=github-releases depName=erlang/otp extractVersion=^OTP-(?<version>.+)$
-ARG ERLANG_VERSION=27.3.4.10
+ARG ERLANG_VERSION=27.3.4.15
 ARG RABBITMQ_VERSION=3.12.14
 
 # Install build dependencies


### PR DESCRIPTION
Backport of the changes in 73d5ce4 (PR #151, merged to `main`), adapted to `server-4.10`.

This branch has no `postgres/14`, so only the applicable pieces are included:

- **postgres/18**: `18.2` → `18.4`. Clears the `ccc-image-scan` Wiz policy failures on HIGH-severity PostgreSQL CVEs: CVE-2026-6473, -6475, -6476, -6477, -6479, -6637, -6638 (all fixed in 18.4).
- **rabbitmq/3**: Erlang `27.3.4.10` → `27.3.4.15` (matches `main`).

Source tarballs for both versions verified present upstream. Erlang 27.3.4.15 already built green in `main`'s `publish-rabbitmq/3`; PostgreSQL 18.4 gets its first CI scan here (main has no pg18 publish job).