### PR TITLE
Backport to server-4.9: Erlang 27.3.4.15

### DIFF
--- a/rabbitmq/3/Dockerfile
+++ b/rabbitmq/3/Dockerfile
@@ -5,7 +5,7 @@
 FROM debian:bookworm-slim AS builder
 
 # renovate: datasource=github-releases depName=erlang/otp extractVersion=^OTP-(?<version>.+)$
-ARG ERLANG_VERSION=27.3.4.10
+ARG ERLANG_VERSION=27.3.4.15
 ARG RABBITMQ_VERSION=3.12.14
 
 # Install build dependencies


### PR DESCRIPTION
Backport of the Erlang portion of 73d5ce4 (PR #151, merged to `main`).

- **rabbitmq/3**: Erlang `27.3.4.10` → `27.3.4.15`.

The Postgres CVE bumps from that commit do **not** apply to `server-4.9`: this branch has no `postgres/14` or `postgres/18` (it ships only `postgresql/13`), so Erlang is the only relevant change. Erlang 27.3.4.15 already built green in `main`.