### PR TITLE
renovate: fix renovate configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ executors:
 workflows:
   my-workflow:
     jobs:
+      - verify-renovate-config
       - image:
           name: "scan-<< matrix.service_path >>"
           command: scan
@@ -52,6 +53,15 @@ workflows:
           filters: *publish_filters
 
 jobs:
+  verify-renovate-config:
+    docker:
+      - image: renovate/renovate:latest
+    steps:
+      - checkout
+      - run:
+          name: "Validate Renovate config"
+          command: renovate-config-validator --strict --no-global renovate.json
+
   image:
     executor: ccc
     parameters:

--- a/mongodb/7/Dockerfile
+++ b/mongodb/7/Dockerfile
@@ -4,6 +4,7 @@
 
 FROM docker.io/bitnami/minideb:bookworm
 
+# renovate: datasource=github-tags depName=mongodb/mongo extractVersion=^r(?<version>.+)$
 ARG MONGODB_VERSION=7.0.15
 
 ENV HOME="/" \

--- a/postgres/13/Dockerfile
+++ b/postgres/13/Dockerfile
@@ -10,6 +10,7 @@ ENV POSTGRESQL_BASE_DIR "/opt/bitnami/postgresql"
 ENV PATH="${POSTGRESQL_BASE_DIR}/bin:${PATH}"
 
 # Install PostgreSQL
+# renovate: datasource=docker depName=postgres versioning=regex:^(?<major>\d+)\.(?<minor>\d+)$
 ARG POSTGRES_VERSION=13.23
 ENV POSTGRESQL_VERSION ${POSTGRES_VERSION}
 RUN install_packages clang dirmngr gosu gnupg libclang-dev libicu-dev libipc-run-perl libkrb5-dev libldap2-dev liblz4-dev locales libpam-dev libperl-dev libpython3-dev libreadline-dev libssl-dev libxml2-dev libxslt1-dev llvm llvm-dev postgresql-server-dev-all python3-dev tcl-dev uuid-dev
@@ -43,6 +44,7 @@ RUN curl -sSL "https://ftp.postgresql.org/pub/source/v${POSTGRESQL_VERSION}/post
 	make clean
 
 # Install pgAudit
+# renovate: datasource=github-tags depName=pgaudit/pgaudit versioning=loose
 ENV POSTGRESQL_PGAUDIT_VERSION 1.5.3
 RUN curl -sSL "https://github.com/pgaudit/pgaudit/archive/${POSTGRESQL_PGAUDIT_VERSION}.tar.gz" | tar -xz && \
     cd pgaudit-${POSTGRESQL_PGAUDIT_VERSION} && \
@@ -50,6 +52,7 @@ RUN curl -sSL "https://github.com/pgaudit/pgaudit/archive/${POSTGRESQL_PGAUDIT_V
     make -j $(nproc) USE_PGXS=1 install
 
 # Install pgAutoFailover
+# renovate: datasource=github-tags depName=hapostgres/pg_auto_failover versioning=loose extractVersion=^v(?<version>.+)$
 ENV POSTGRESQL_AUTOCTL_VERSION 2.0
 RUN curl -sSL "https://github.com/citusdata/pg_auto_failover/archive/v${POSTGRESQL_AUTOCTL_VERSION}.tar.gz" | tar -xz && \
     cd pg_auto_failover-${POSTGRESQL_AUTOCTL_VERSION} && \
@@ -58,6 +61,7 @@ RUN curl -sSL "https://github.com/citusdata/pg_auto_failover/archive/v${POSTGRES
     make clean
 
 # Install pgBackRest
+# renovate: datasource=github-tags depName=pgbackrest/pgbackrest versioning=loose extractVersion=^release/(?<version>.+)$
 ENV POSTGRESQL_PGBACKREST_VERSION 2.47
 RUN curl -sSL "https://github.com/pgbackrest/pgbackrest/archive/release/${POSTGRESQL_PGBACKREST_VERSION}.tar.gz" | tar -xz && \
     cd pgbackrest-release-${POSTGRESQL_PGBACKREST_VERSION}/src && \
@@ -65,6 +69,7 @@ RUN curl -sSL "https://github.com/pgbackrest/pgbackrest/archive/release/${POSTGR
     make -j $(nproc) && \
     make -j $(nproc) install
 
+# renovate: datasource=gitlab-tags depName=cwrap/nss_wrapper extractVersion=^nss_wrapper-(?<version>.+)$
 ENV NSS_WRAPPER_VERSION 1.1.15
 RUN install_packages cmake
 RUN curl -sSL "https://ftp.samba.org/pub/cwrap/nss_wrapper-${NSS_WRAPPER_VERSION}.tar.gz" | tar -xz && \
@@ -75,6 +80,7 @@ RUN curl -sSL "https://ftp.samba.org/pub/cwrap/nss_wrapper-${NSS_WRAPPER_VERSION
     make clean
 
 # Install pg_partman
+# renovate: datasource=github-tags depName=pgpartman/pg_partman extractVersion=^v(?<version>.+)$
 ENV POSTGRESQL_PG_PARTMAN_VERSION 4.7.2
 RUN curl -sSL "https://github.com/pgpartman/pg_partman/archive/v${POSTGRESQL_PG_PARTMAN_VERSION}.tar.gz" | tar -xz && \
 	cd pg_partman-${POSTGRESQL_PG_PARTMAN_VERSION} && \

--- a/postgres/14/Dockerfile
+++ b/postgres/14/Dockerfile
@@ -10,6 +10,7 @@ ENV POSTGRESQL_BASE_DIR "/opt/bitnami/postgresql"
 ENV PATH="${POSTGRESQL_BASE_DIR}/bin:${PATH}"
 
 # Install PostgreSQL
+# renovate: datasource=docker depName=postgres versioning=regex:^(?<major>\d+)\.(?<minor>\d+)$
 ARG POSTGRES_VERSION=14.23
 ENV POSTGRESQL_VERSION ${POSTGRES_VERSION}
 RUN install_packages clang dirmngr gosu gnupg libclang-dev libicu-dev libipc-run-perl libkrb5-dev libldap2-dev liblz4-dev locales libpam-dev libperl-dev libpython3-dev libreadline-dev libssl-dev libxml2-dev libxslt1-dev llvm llvm-dev postgresql-server-dev-all python3-dev tcl-dev uuid-dev
@@ -43,6 +44,7 @@ RUN curl -sSL "https://ftp.postgresql.org/pub/source/v${POSTGRESQL_VERSION}/post
 	make clean
 
 # Install pgAudit
+# renovate: datasource=github-tags depName=pgaudit/pgaudit versioning=loose
 ENV POSTGRESQL_PGAUDIT_VERSION 1.7.1
 RUN curl -sSL "https://github.com/pgaudit/pgaudit/archive/${POSTGRESQL_PGAUDIT_VERSION}.tar.gz" | tar -xz && \
     cd pgaudit-${POSTGRESQL_PGAUDIT_VERSION} && \
@@ -50,6 +52,7 @@ RUN curl -sSL "https://github.com/pgaudit/pgaudit/archive/${POSTGRESQL_PGAUDIT_V
     make -j $(nproc) USE_PGXS=1 install
 
 # Install pgAutoFailover
+# renovate: datasource=github-tags depName=hapostgres/pg_auto_failover versioning=loose extractVersion=^v(?<version>.+)$
 ENV POSTGRESQL_AUTOCTL_VERSION 2.0
 RUN curl -sSL "https://github.com/citusdata/pg_auto_failover/archive/v${POSTGRESQL_AUTOCTL_VERSION}.tar.gz" | tar -xz && \
     cd pg_auto_failover-${POSTGRESQL_AUTOCTL_VERSION} && \
@@ -58,6 +61,7 @@ RUN curl -sSL "https://github.com/citusdata/pg_auto_failover/archive/v${POSTGRES
     make clean
 
 # Install pgBackRest
+# renovate: datasource=github-tags depName=pgbackrest/pgbackrest versioning=loose extractVersion=^release/(?<version>.+)$
 ENV POSTGRESQL_PGBACKREST_VERSION 2.47
 RUN curl -sSL "https://github.com/pgbackrest/pgbackrest/archive/release/${POSTGRESQL_PGBACKREST_VERSION}.tar.gz" | tar -xz && \
     cd pgbackrest-release-${POSTGRESQL_PGBACKREST_VERSION}/src && \
@@ -65,6 +69,7 @@ RUN curl -sSL "https://github.com/pgbackrest/pgbackrest/archive/release/${POSTGR
     make -j $(nproc) && \
     make -j $(nproc) install
 
+# renovate: datasource=gitlab-tags depName=cwrap/nss_wrapper extractVersion=^nss_wrapper-(?<version>.+)$
 ENV NSS_WRAPPER_VERSION 1.1.16
 RUN install_packages cmake
 RUN curl -sSL "https://ftp.samba.org/pub/cwrap/nss_wrapper-${NSS_WRAPPER_VERSION}.tar.gz" | tar -xz && \
@@ -75,6 +80,7 @@ RUN curl -sSL "https://ftp.samba.org/pub/cwrap/nss_wrapper-${NSS_WRAPPER_VERSION
     make clean
 
 # Install pg_partman
+# renovate: datasource=github-tags depName=pgpartman/pg_partman extractVersion=^v(?<version>.+)$
 ENV POSTGRESQL_PG_PARTMAN_VERSION 4.7.4
 RUN curl -sSL "https://github.com/pgpartman/pg_partman/archive/v${POSTGRESQL_PG_PARTMAN_VERSION}.tar.gz" | tar -xz && \
 	cd pg_partman-${POSTGRESQL_PG_PARTMAN_VERSION} && \

--- a/postgres/18/Dockerfile
+++ b/postgres/18/Dockerfile
@@ -10,6 +10,7 @@ ENV POSTGRESQL_BASE_DIR "/opt/bitnami/postgresql"
 ENV PATH="${POSTGRESQL_BASE_DIR}/bin:${PATH}"
 
 # Install PostgreSQL
+# renovate: datasource=docker depName=postgres versioning=regex:^(?<major>\d+)\.(?<minor>\d+)$
 ARG POSTGRES_VERSION=18.4
 ENV POSTGRESQL_VERSION ${POSTGRES_VERSION}
 RUN install_packages bison clang dirmngr flex gosu gnupg libclang-dev libicu-dev libipc-run-perl libkrb5-dev libldap2-dev liblz4-dev locales libpam-dev libperl-dev libpython3-dev libreadline-dev libssl-dev libxml2-dev libxslt1-dev llvm llvm-dev meson ninja-build postgresql-server-dev-all python3-dev tcl-dev uuid-dev
@@ -39,6 +40,7 @@ RUN curl -sSL "https://ftp.postgresql.org/pub/source/v${POSTGRESQL_VERSION}/post
 	make clean
 
 # Install pgAudit
+# renovate: datasource=github-tags depName=pgaudit/pgaudit versioning=loose
 ENV POSTGRESQL_PGAUDIT_VERSION 18.0
 RUN curl -sSL "https://github.com/pgaudit/pgaudit/archive/${POSTGRESQL_PGAUDIT_VERSION}.tar.gz" | tar -xz && \
     cd pgaudit-${POSTGRESQL_PGAUDIT_VERSION} && \
@@ -54,6 +56,7 @@ RUN curl -sSL "https://github.com/hapostgres/pg_auto_failover/archive/refs/heads
     make clean
 
 # Install pgBackRest
+# renovate: datasource=github-tags depName=pgbackrest/pgbackrest versioning=loose extractVersion=^release/(?<version>.+)$
 ENV POSTGRESQL_PGBACKREST_VERSION 2.58.0
 RUN curl -sSL "https://github.com/pgbackrest/pgbackrest/archive/release/${POSTGRESQL_PGBACKREST_VERSION}.tar.gz" | tar -xz && \
     cd pgbackrest-release-${POSTGRESQL_PGBACKREST_VERSION} && \
@@ -61,6 +64,7 @@ RUN curl -sSL "https://github.com/pgbackrest/pgbackrest/archive/release/${POSTGR
     ninja -C build && \
     ninja -C build install
 
+# renovate: datasource=gitlab-tags depName=cwrap/nss_wrapper extractVersion=^nss_wrapper-(?<version>.+)$
 ENV NSS_WRAPPER_VERSION 1.1.15
 RUN install_packages cmake
 RUN curl -sSL "https://ftp.samba.org/pub/cwrap/nss_wrapper-${NSS_WRAPPER_VERSION}.tar.gz" | tar -xz && \
@@ -72,6 +76,7 @@ RUN curl -sSL "https://ftp.samba.org/pub/cwrap/nss_wrapper-${NSS_WRAPPER_VERSION
 
 # Install pg_partman
 # N.b., pinned to v4.x as v5.x dropped the 'daily' interval type, breaking existing migrations.
+# renovate: datasource=github-tags depName=pgpartman/pg_partman extractVersion=^v(?<version>.+)$
 ENV POSTGRESQL_PGPARTMAN_VERSION 4.7.4
 RUN curl -sSL "https://github.com/pgpartman/pg_partman/archive/refs/tags/v${POSTGRESQL_PGPARTMAN_VERSION}.tar.gz" | tar -xz && \
 	cd pg_partman-${POSTGRESQL_PGPARTMAN_VERSION} && \

--- a/rabbitmq/3/Dockerfile
+++ b/rabbitmq/3/Dockerfile
@@ -4,8 +4,9 @@
 
 FROM debian:bookworm-slim AS builder
 
-# renovate: datasource=github-releases depName=erlang/otp extractVersion=^OTP-(?<version>.+)$
+# renovate: datasource=github-releases depName=erlang/otp versioning=loose extractVersion=^OTP-(?<version>.+)$
 ARG ERLANG_VERSION=27.3.4.15
+# renovate: datasource=github-releases depName=rabbitmq/rabbitmq-server extractVersion=^v(?<version>.+)$
 ARG RABBITMQ_VERSION=3.12.14
 
 # Install build dependencies
@@ -34,6 +35,7 @@ RUN curl -1sLf https://github.com/rabbitmq/rabbitmq-server/releases/download/v${
 FROM debian:bookworm-slim
 
 ARG TARGETARCH
+# renovate: datasource=github-releases depName=rabbitmq/rabbitmq-server extractVersion=^v(?<version>.+)$
 ARG RABBITMQ_VERSION=3.12.14
 
 LABEL maintainer="On-Prem Team <on-prem@circleci.com>"

--- a/redis/6/Dockerfile
+++ b/redis/6/Dockerfile
@@ -5,6 +5,7 @@
 # Build stage for Redis
 FROM docker.io/bitnami/minideb:buster as redis-builder
 
+# renovate: datasource=github-tags depName=redis/redis
 ARG REDIS_VERSION=6.2.20
 
 RUN sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list && \

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,86 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>circleci/renovate-config", "github>circleci/renovate-config:default"]
+  "enabled": true,
+  "baseBranchPatterns": [
+    "/^main$/",
+    "/^server-4\\.(9|10)$/"
+  ],
+  "extends": [
+    "config:recommended",
+    "mergeConfidence:all-badges",
+    "abandonments:recommended",
+    ":maintainLockFilesDisabled",
+    ":docker",
+    ":separateMajorReleases",
+    "customManagers:dockerfileVersions"
+  ],
+  "schedule": ["* * * * 0"],
+  "timezone": "America/Toronto",
+  "configMigration": true,
+  "labels": ["renovate"],
+  "vulnerabilityAlerts": {
+    "addLabels": [
+      "CVE",
+      "security"
+    ],
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true,
+  "minimumReleaseAge": "7 days",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
+  "internalChecksFilter": "strict",
+  "prCreation": "not-pending",
+  "packageRules": [
+    {
+      "description": "[inherited]: Set sourceUrl for circleci orbs, so changelogs are included",
+      "matchDatasources": ["orb"],
+      "matchPackageNames": ["circleci/*"],
+      "sourceUrl": "https://github.com/CircleCI-Public/{{ lookup (split packageName '/') 1 }}-orb"
+    },
+    {
+      "description": "Dockerfile-pinned dependency versions (MongoDB, PostgreSQL, RabbitMQ, Redis, Erlang, and the Postgres extensions): propose only the smallest (patch) upgrades. Minor and major are disabled here and selectively re-enabled below.",
+      "matchManagers": ["custom.regex"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
+      "description": "PostgreSQL uses major.minor versioning with no patch component, so a minor bump (e.g. 14.22 -> 14.23) is its smallest possible upgrade. Allow minor; major (14 -> 15) stays disabled by the rule above.",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["postgres"],
+      "matchUpdateTypes": ["minor"],
+      "enabled": true
+    },
+    {
+      "description": "Fallback: allow a minor upgrade for Dockerfile-pinned versions only when it resolves a vulnerability.",
+      "matchManagers": ["custom.regex"],
+      "matchJsonata": ["$exists(isVulnerabilityAlert) and isVulnerabilityAlert = true"],
+      "matchUpdateTypes": ["minor"],
+      "enabled": true
+    },
+    {
+      "description": "Disable all updates for server branches; CVE/security updates are re-enabled below.",
+      "matchBaseBranches": [
+        "/^server-4\\.(9|10)$/"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Automerge CVE/Security updates for server branches during weekday business hours.",
+      "matchBaseBranches": [
+        "/^server-4\\.(9|10)$/"
+      ],
+      "matchJsonata": ["$exists(isVulnerabilityAlert) and isVulnerabilityAlert = true"],
+      "enabled": true,
+      "automerge": true,
+      "automergeSchedule": [
+        "* 8-17 * * 1-5"
+      ],
+      "addLabels": [
+        "AUTOMERGE",
+        "CVE",
+        "security",
+        "server"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## What

This brings parts of the private Renovate configuration to live here, as public repositories cannot inherit from private shared configs.

Fixes https://github.com/circleci/server-docker-images/issues/147.

## What else

Some of the key points about how things are customized for this project:

1. Disable major updates unless they are vulnerability-related.
2. Also maintain versions declared in Dockerfiles.
3. Validate renovate configuration changes as part of the CI workflow